### PR TITLE
MP: Remove MP_PHY leftovers and fix uniphy reset

### DIFF
--- a/include/init/ssdk_clk.h
+++ b/include/init/ssdk_clk.h
@@ -241,19 +241,29 @@ enum cmnblk_pll_src_type {
 };
 
 enum mp_bcr_rst_type {
+#if defined(IN_MP_PHY)
 	GEPHY_BCR_RESET_E = 0,
 	UNIPHY_BCR_RESET_E,
+#else
+	UNIPHY_BCR_RESET_E = 0,
+#endif
 	GMAC0_BCR_RESET_E,
 	GMAC1_BCR_RESET_E,
+#if defined(IN_MP_PHY)
 	GEPHY_MISC_RESET_E,
+#endif
 	MP_BCR_RST_MAX
 };
 
+#if defined(IN_MP_PHY)
 #define GEHPY_BCR_RESET_ID	"gephy_bcr_rst"
+#endif
 #define UNIPHY_BCR_RESET_ID	"uniphy_bcr_rst"
 #define GMAC0_BCR_RESET_ID	"gmac0_bcr_rst"
 #define GMAC1_BCR_RESET_ID	"gmac1_bcr_rst"
+#if defined(IN_MP_PHY)
 #define GEPHY_MISC_RESET_ID	"gephy_misc_rst"
+#endif
 
 #define CMN_BLK_ADDR                0x0009B780
 #define CMN_BLK_PLL_SRC_ADDR        0x0009B028

--- a/src/adpt/mp/adpt_mp_uniphy.c
+++ b/src/adpt/mp/adpt_mp_uniphy.c
@@ -119,10 +119,19 @@ void
 adpt_mp_gcc_uniphy_port_set(a_uint32_t dev_id, a_uint32_t port_id,
 	a_bool_t enable)
 {
+	a_bool_t force_port = A_FALSE;
 	enum unphy_rst_type rst_type;
 
 	if (port_id == SSDK_PHYSICAL_PORT2) {
-		rst_type = UNIPHY1_SOFT_RESET_E;
+		force_port = hsl_port_feature_get(dev_id, SSDK_PHYSICAL_PORT2, PHY_F_FORCE);
+		/*
+		 * for fixed-link: reset AHB only
+		 * for phy-to-phy: do soft reset (SYS, RX, and TX)
+		 */
+		if (force_port)
+			rst_type = UNIPHY1_AHB_RESET_E;
+		else
+			rst_type = UNIPHY1_SOFT_RESET_E;
 	} else {
 		return;
 	}

--- a/src/init/ssdk_clk.c
+++ b/src/init/ssdk_clk.c
@@ -1027,24 +1027,31 @@ static void ssdk_ppe_fixed_clock_init(adpt_ppe_type_t chip_type)
 #if defined(MP)
 #define TCSR_ETH_ADDR               0x19475C0
 #define TCSR_ETH_SIZE               0x4
+#if defined(IN_MP_PHY)
 #define TCSR_GEPHY_LDO_BIAS_EN      0
 #define TCSR_ETH_LDO_RDY            0x4
 
 #define GEPHY_LDO_BIAS_EN           0x1
 #define ETH_LDO_RDY                 0x1
+#endif
 #define CMN_PLL_LOCKED_ADDR         0x9B064
 #define CMN_PLL_LOCKED_SIZE         0x4
 #define CMN_PLL_LOCKED              0x4
 #define MP_RAW_CLOCK_INSTANCE       0x2
 
 static char *mp_rst_ids[MP_BCR_RST_MAX] = {
+#if defined(IN_MP_PHY)
 	GEHPY_BCR_RESET_ID,
+#endif
 	UNIPHY_BCR_RESET_ID,
 	GMAC0_BCR_RESET_ID,
 	GMAC1_BCR_RESET_ID,
+#if defined(IN_MP_PHY)
 	GEPHY_MISC_RESET_ID
+#endif
 };
 
+#if defined(IN_MP_PHY)
 static struct clk_uniphy gephy_gcc_rx_clk = {
 	.hw.init = &(struct clk_init_data){
 	.name = "gephy_gcc_rx",
@@ -1070,6 +1077,7 @@ static struct clk_uniphy gephy_gcc_tx_clk = {
 	.dir = UNIPHY_TX,
 	.rate = UNIPHY_DEFAULT_RATE,
 };
+#endif
 
 static struct clk_uniphy uniphy_gcc_rx_clk = {
 	.hw.init = &(struct clk_init_data){
@@ -1097,8 +1105,12 @@ static struct clk_uniphy uniphy_gcc_tx_clk = {
 	.rate = UNIPHY_DEFAULT_RATE,
 };
 
+#if defined(IN_MP_PHY)
 static struct clk_hw *mp_raw_clks[MP_RAW_CLOCK_INSTANCE * 2] = {
 	&gephy_gcc_rx_clk.hw, &gephy_gcc_tx_clk.hw,
+#else
+static struct clk_hw *mp_raw_clks[MP_RAW_CLOCK_INSTANCE] = {
+#endif
 	&uniphy_gcc_rx_clk.hw, &uniphy_gcc_tx_clk.hw,
 };
 
@@ -1178,6 +1190,7 @@ static void ssdk_mp_uniphy_clock_enable(void)
 	ssdk_uniphy_clock_enable(0, UNIPHY1_PORT5_TX_CLK_E, A_TRUE);
 }
 
+#if defined(IN_MP_PHY)
 static void
 ssdk_mp_tcsr_get(a_uint32_t tcsr_offset, a_uint32_t *tcsr_val)
 {
@@ -1270,6 +1283,7 @@ ssdk_mp_cmnblk_stable_check(void)
 		return A_TRUE;
 	}
 }
+#endif
 
 static void
 ssdk_mp_reset_init(void)
@@ -1645,13 +1659,17 @@ void ssdk_gcc_mp_clock_init(enum cmnblk_clk_type mode)
 	ssdk_mp_uniphy_clock_init();
 	ssdk_cmnblk_init(mode);
 	msleep(200);
+#if defined(IN_MP_PHY)
 	ssdk_mp_cmnblk_enable();
 	if (ssdk_mp_cmnblk_stable_check()) {
+#endif
 		ssdk_mp_reset_init();
 		ssdk_mp_uniphy_clock_enable();
+#if defined(IN_MP_PHY)
 	} else {
 		SSDK_ERROR("Cmnblock is still not stable!\n");
 	}
+#endif
 #endif
 }
 
@@ -1675,7 +1693,14 @@ void ssdk_mp_raw_clock_set(
 		return;
 	}
 
+	/* in MP, there is only 1 uniphy and its index is always 1 */
+#if defined(IN_MP_PHY)
+	/* uniphy clocks have idx 2 and 3 in mp_raw_clks[] */
 	id = uniphy_index*2 + direction;
+#else
+	/* uniphy clocks have idx 0 and 1 in mp_raw_clks[] */
+	id = direction;
+#endif
 	old_clock = clk_get_rate(mp_raw_clks[id]->clk);
 
 	if (clock != old_clock) {

--- a/src/init/ssdk_clk.c
+++ b/src/init/ssdk_clk.c
@@ -1305,8 +1305,8 @@ ssdk_mp_reset_init(void)
 		reset_control_put(rst);
 	}
 
-	i = UNIPHY1_SOFT_RESET_E;
-	uniphy_rsts[i] = of_reset_control_get(rst_node, UNIPHY1_SOFT_RESET_ID);
+	uniphy_rsts[UNIPHY1_AHB_RESET_E] = of_reset_control_get(rst_node, UNIPHY1_AHB_RESET_ID);
+	uniphy_rsts[UNIPHY1_SOFT_RESET_E] = of_reset_control_get(rst_node, UNIPHY1_SOFT_RESET_ID);
 
 	SSDK_INFO("MP reset successfully!\n");
 #endif

--- a/src/init/ssdk_mp.c
+++ b/src/init/ssdk_mp.c
@@ -59,10 +59,12 @@ qca_mp_portctrl_hw_init(a_uint32_t dev_id)
 		fal_port_promisc_mode_set(dev_id, i, A_TRUE);
 		/* init software level port status */
 		qca_mac_port_status_init(dev_id, i);
+#if defined(IN_MP_UNIPHY)
 		/*enable ICC efuse loading*/
 		ssdk_mp_gephy_icc_efuse_load_enable(A_TRUE);
 #ifdef IN_LED
 		ssdk_led_init(dev_id, i);
+#endif
 #endif
 	}
 	return rv;


### PR DESCRIPTION
This patch set contains is part of a larger change and contains commits 2 and 5 out of total of 6.
The three others have been submitted to openwrt.

**Commit 2**: 
ssdk_clk: Remove MP_PHY clocks resets and init logic
    
While commit 81d3888 disables the init function for MP_PHY as there's a
native linux driver for the IPQ5018 PHY, the SSDK has the PHY's clock
and reset ops mixed in functions that cover different components.
In addition, the enablement of the LDO controller is part of and taken
care of by the upstream mdio-ipq4019 driver.
So let's add preprocessor directives to disable compilation and avoid
unpredictable clock and reset behavior.

**Commit 5**:
MP: fix uniphy reset in phy to phy link scenario
    
Uniphy supports fixed link and phy to phy link architectures.
Prior to below patch issued by QCA to fix the uniphy reset in the GCC,
the reset bit - BIT(0) - triggered an AHB reset which worked well for
fixed link scenarios. After the patch was applied, it was set to a
bitmask, triggering resets for the uniphy SYS, RX, and TX clocks which
are needed in phy to phy link setups to support shifting between link
speeds (1G & 2.5G for MP). This broke fixed links, however. So let's
trigger the right reset based on the link architecture.