### PR TITLE
make: honor SOURCE_DATE_EPOCH in BUILD_DATE

### DIFF
--- a/make/config.mk
+++ b/make/config.mk
@@ -136,4 +136,8 @@ BIN_DIR=$(PRJ_PATH)/build/bin
 VER=3.1.0
 BUILD_NUMBER=$(shell cat $(PRJ_PATH)/make/.build_number)
 VERSION=$(VER).$(BUILD_NUMBER)
-BUILD_DATE=$(shell date -u  +%F-%T)
+ifneq ($(SOURCE_DATE_EPOCH),)
+  BUILD_DATE:=$(shell perl -MPOSIX -e 'print strftime("%F-%T", gmtime($(SOURCE_DATE_EPOCH)))')
+else
+  BUILD_DATE:=$(shell date -u +%F-%T)
+endif


### PR DESCRIPTION
The BUILD_DATE string is embedded into qca-ssdk.ko via -DBUILD_DATE=... (make/linux_opt.mk) and aos_mem_copy() in src/hsl/hsl_dev.c, so its unconditional shell-out to date(1) makes every build produce a different .ko -- breaking reproducible builds and preventing bit-identical OpenWrt firmware images.

When SOURCE_DATE_EPOCH is set (the reproducible-builds convention, exported by OpenWrt from include/toplevel.mk), derive BUILD_DATE from it via perl + POSIX::strftime. Same idiom as OpenWrt's own include/kernel.mk, and portable across BSD/macOS where date(1) lacks -d @<epoch>. The %F-%T format is preserved, so the embedded string is byte-for-byte interchangeable with the previous one.

Falls back to the existing date(1) invocation when SOURCE_DATE_EPOCH is unset, leaving standalone qca-ssdk builds unaffected.

fixes #5 