### PR TITLE
Revert "MP: fix uniphy reset in phy to phy link scenario"

### DIFF
--- a/src/adpt/mp/adpt_mp_uniphy.c
+++ b/src/adpt/mp/adpt_mp_uniphy.c
@@ -119,19 +119,10 @@ void
 adpt_mp_gcc_uniphy_port_set(a_uint32_t dev_id, a_uint32_t port_id,
 	a_bool_t enable)
 {
-	a_bool_t force_port = A_FALSE;
 	enum unphy_rst_type rst_type;
 
 	if (port_id == SSDK_PHYSICAL_PORT2) {
-		force_port = hsl_port_feature_get(dev_id, SSDK_PHYSICAL_PORT2, PHY_F_FORCE);
-		/*
-		 * for fixed-link: reset AHB only
-		 * for phy-to-phy: do soft reset (SYS, RX, and TX)
-		 */
-		if (force_port)
-			rst_type = UNIPHY1_AHB_RESET_E;
-		else
-			rst_type = UNIPHY1_SOFT_RESET_E;
+		rst_type = UNIPHY1_SOFT_RESET_E;
 	} else {
 		return;
 	}

--- a/src/init/ssdk_clk.c
+++ b/src/init/ssdk_clk.c
@@ -1305,8 +1305,8 @@ ssdk_mp_reset_init(void)
 		reset_control_put(rst);
 	}
 
-	uniphy_rsts[UNIPHY1_AHB_RESET_E] = of_reset_control_get(rst_node, UNIPHY1_AHB_RESET_ID);
-	uniphy_rsts[UNIPHY1_SOFT_RESET_E] = of_reset_control_get(rst_node, UNIPHY1_SOFT_RESET_ID);
+	i = UNIPHY1_SOFT_RESET_E;
+	uniphy_rsts[i] = of_reset_control_get(rst_node, UNIPHY1_SOFT_RESET_ID);
 
 	SSDK_INFO("MP reset successfully!\n");
 #endif


### PR DESCRIPTION
This reverts commit 446db12b1fd3bca2e61e45cb01c4ad52cfddd95b.

When the UNIPHY SOFT reset bitmap was corrected in the GCC, fixed links stopped working. The SOFT reset bitmap prior to the fix was the same as for the AHB reset and coincidentally it was working, probably due to the reset causing the right register values or triggering inband negotiation. So the AHB reset was added to make fixed links work again. Though this wasn't the actual root cause of the issue.

The upstream QCA8K DSA switch driver did not support force mode which is required for fixed links. So revert this change as this is not the actual solution.